### PR TITLE
Fix for compressed data handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,7 +485,7 @@ function readCompressedData(buffer, state) {
   }
   const compressedData = Buffer.concat(chunks);
 
-  return zlib.unzipSync(compressedData, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
+  return zlib.unzipSync(compressedData, { finishFlush: zlib.Z_SYNC_FLUSH });
 }
 
 function myBufferFrom(source) {

--- a/index.js
+++ b/index.js
@@ -485,7 +485,7 @@ function readCompressedData(buffer, state) {
   }
   const compressedData = Buffer.concat(chunks);
 
-  return zlib.deflateSync(compressedData, { finishFlush: zlib.Z_SYNC_FLUSH });
+  return zlib.unzipSync(compressedData, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
 }
 
 function myBufferFrom(source) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -273,18 +273,12 @@ describe('Parse file with string longer than null terminator', () => {
 });
 
 describe('Test decompression', () => {
-  it('Sometimes works and sometimes doesn\'t, wish I knew why...', () => {
-    const badSaves = ['000144.Civ6Save', 'HŌJŌ TOKIMUNE 341 1920 d. C..Civ6Save'];
-
+  it('should work with all save files', () => {
     for (const save of fs.readdirSync('test/saves')) {
       const buffer = new Buffer(fs.readFileSync('test/saves/' + save));
       const parseFunc = () => civ6.parse(buffer, { outputCompressed: true });
   
-      if (badSaves.indexOf(save) >= 0) {
-        expect(parseFunc, save).to.throw();
-      } else {
-        expect(parseFunc, save).to.not.throw();
-      }
+      expect(parseFunc, save).to.not.throw();
     }
   });
 });


### PR DESCRIPTION
I noticed that there are 4 extra bytes in compressed data after every chunk of 64 kilobytes. Not sure what those bytes are for, but they are not part of deflated data.