### PR TITLE
Supported setting boolean flags in chunks of type boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,6 +251,9 @@ function writeValue(marker, type, value) {
     case DATA_TYPES.STRING:
       return writeString(marker, value);
 
+    case DATA_TYPES.BOOLEAN:
+      return writeBoolean(marker, value);
+
     default:
       throw new Error('I don\'t know how to write type ' + type);
   }
@@ -517,6 +520,13 @@ function writeArrayLen(marker, value) {
   valueBuffer.writeUInt32LE(value);
 
   return Buffer.concat([marker, new Buffer([0x0A, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0]), valueBuffer]);
+}
+
+function writeBoolean(marker, value) {
+  const valueBuffer = Buffer.alloc(4);
+  valueBuffer.writeUInt32LE(value ? 1 : 0);
+
+  return Buffer.concat([marker, Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), valueBuffer]);
 }
 
 function readCompressedData(buffer, state) {

--- a/test/modifyCiv.js
+++ b/test/modifyCiv.js
@@ -66,6 +66,15 @@ describe('Modify Cathy Save', function() {
     expect(data.parsed.CIVS[1].ACTOR_AI_HUMAN.data).to.equal(1);
   });
 
+  it('should be able to change flag that it\'s current player\'s turn', () => {
+    expect(data.parsed.CIVS[0].IS_CURRENT_TURN.data).to.equal(true);
+
+    civ6.modifyChunk(data.chunks, data.parsed.CIVS[0].IS_CURRENT_TURN, false);
+    data = civ6.parse(Buffer.concat(data.chunks));
+
+    expect(data.parsed.CIVS[0].IS_CURRENT_TURN.data).to.equal(false);
+  });
+
   /* it('writes the modified save file for debugging purposes', () => {
     fs.writeFileSync('test/saves/modified.Civ6Save', Buffer.concat(data.chunks));
   });*/


### PR DESCRIPTION
This change is necessary for setting IS_CURRENT_TURN flag for players.
Setting it will enable fixing the long standing issue where game hangs when you switch current player to AI and the to Human back again (https://discourse.playyourdamnturn.com/t/turn-timer/63/6)